### PR TITLE
Update of Americium to 1.5.1

### DIFF
--- a/pbt-libraries/americium/build.sbt
+++ b/pbt-libraries/americium/build.sbt
@@ -18,7 +18,7 @@ lazy val settings = Seq(
     case _ => Nil
   }),
   javacOptions ++= Seq("-source", javaVersion, "-target", javaVersion),
-  libraryDependencies += "com.sageserpent" %% "americium" % "1.4.6",
+  libraryDependencies += "com.sageserpent" %% "americium" % "1.5.1",
   libraryDependencies += "org.scalatest"  %% "scalatest"  % "3.2.9"  % Test,
   libraryDependencies += "org.assertj" % "assertj-core" % "3.19.0",
   libraryDependencies += "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,

--- a/pbt-libraries/americium/reports/binheap.md
+++ b/pbt-libraries/americium/reports/binheap.md
@@ -1,20 +1,20 @@
 # Report for Americium Shrinking on "binheap"
 
-This report was generated with Americium 1.4.6
+This report was generated with Americium 1.5.1
 
 ## Normalization
 
 Americium currently uses a fixed internal randomisation seed, so always yields the same shrinkage:
 
-* ``[[0,[0,[0,None,None],[1,None,None]],None]]`` - casesLimit = 170
+* ``[[0,[0,[0,None,None],[1,None,None]],None]]`` - casesLimit = 190
 
 
 ## Performance
 
-5747 cases were run.
+8075 cases were run.
 
-3 successful runs were performed out of a limit of 170 successful cases, prior to the first failing case.
+3 successful runs were performed out of a limit of 190 successful cases, prior to the first failing case.
 
-1 + 41 = 42 runs then failed out of a subsequent shrinkage sequence of 5747 - 3 = 5744 runs, including the first failing case.
+1 + 42 = 43 runs then failed out of a subsequent shrinkage sequence of 8075 - 3 = 8072 runs, including the first failing case.
 
-The best shrunk case was followed by 5747 - 5540 = 207 successful cases in the shrinkage sequence.
+The best shrunk case was followed by 8072 - 7806 = 266 successful cases in the shrinkage sequence.

--- a/pbt-libraries/americium/reports/deletion.md
+++ b/pbt-libraries/americium/reports/deletion.md
@@ -1,6 +1,6 @@
 # Report for Americium Shrinking on "deletion"
 
-This report was generated with Americium 1.4.6
+This report was generated with Americium 1.5.1
 
 ## Normalization
 
@@ -11,12 +11,12 @@ Americium currently uses a fixed internal randomisation seed, so always yields t
 
 ## Performance
 
-372 cases were run.
+202 cases were run.
 
-341 of these were discarded by the test's inline filter, as the removal index was out of range.
+171 of these were discarded by the test's inline filter, as the removal index was out of range.
 
 *No* successful runs were performed out of a limit of 20 successful cases, prior to the first failing case.
 
-1 + 26 = 27 runs then failed out of a subsequent shrinkage sequence of 372 - 8 = 364 runs, including the first failing case.
+1 + 27 = 28 runs then failed out of a subsequent shrinkage sequence of 202 - 8 = 194 runs, including the first failing case.
 
-The best shrunk case was followed by no successful cases and 4 discarded cases in the shrinkage sequence.
+The best shrunk case was followed by no successful cases and 5 discarded cases in the shrinkage sequence.

--- a/pbt-libraries/americium/reports/difference_must_not_be_one.md
+++ b/pbt-libraries/americium/reports/difference_must_not_be_one.md
@@ -1,20 +1,20 @@
 # Report for Americium Shrinking on "difference must not be one"
 
-This report was generated with Americium 1.4.6
+This report was generated with Americium 1.5.1
 
 ## Normalization
 
 Americium currently uses a fixed internal randomisation seed, so always yields the same shrinkage:
 
-* ``[10, 9]`` - casesLimit = 1000
+* ``[10, 9]`` - casesLimit = 2000
 
 
 ## Performance
 
-566 cases were run.
+6896 cases were run.
 
-332 successful runs were performed out of a limit of 1000 successful cases, prior to the first failing case.
+1959 successful runs were performed out of a limit of 2000 successful cases, prior to the first failing case.
 
-1 + 1 = 2 runs then failed out of a subsequent shrinkage sequence of 566 - 332 = 234 runs, including the first failing case.
+1 + 3 = 4 runs then failed out of a subsequent shrinkage sequence of 6896 - 1959 = 4937 runs, including the first failing case.
 
-The best shrunk case was followed by 566 - 391 = 175 successful cases in the shrinkage sequence.
+The best shrunk case was followed by 6896 - 2739 = 4157 successful cases in the shrinkage sequence.

--- a/pbt-libraries/americium/reports/difference_must_not_be_small.md
+++ b/pbt-libraries/americium/reports/difference_must_not_be_small.md
@@ -1,20 +1,20 @@
 # Report for Americium Shrinking on "difference must not be small"
 
-This report was generated with Americium 1.4.2
+This report was generated with Americium 1.5.1
 
 ## Normalization
 
 Americium currently uses a fixed internal randomisation seed, so always yields the same shrinkage:
 
-* ``[10, 6]`` - casesLimit = 150
+* ``[10, 6]`` - casesLimit = 1700
 
 
 ## Performance
 
-296 cases were run.
+9028 cases were run.
 
-126 successful runs were performed out of a limit of 150 successful cases, prior to the first failing case.
+1640 successful runs were performed out of a limit of 1700 successful cases, prior to the first failing case.
 
-1 + 4 = 5 runs then failed out of a subsequent shrinkage sequence of 296 - 126 = 170 runs, including the first failing case.
+1 + 6 = 7 runs then failed out of a subsequent shrinkage sequence of 9028 - 1640 = 7388 runs, including the first failing case.
 
-The best shrunk case was followed by 296 - 210 = 86 successful cases in the shrinkage sequence.
+The best shrunk case was followed by 9028 - 5386 = 3642 successful cases in the shrinkage sequence.

--- a/pbt-libraries/americium/reports/difference_must_not_be_zero.md
+++ b/pbt-libraries/americium/reports/difference_must_not_be_zero.md
@@ -1,6 +1,6 @@
 # Report for Americium Shrinking on "difference must not be zero"
 
-This report was generated with Americium 1.4.2
+This report was generated with Americium 1.4.6
 
 ## Normalization
 

--- a/pbt-libraries/americium/reports/difference_must_not_be_zero.md
+++ b/pbt-libraries/americium/reports/difference_must_not_be_zero.md
@@ -1,20 +1,20 @@
 # Report for Americium Shrinking on "difference must not be zero"
 
-This report was generated with Americium 1.4.6
+This report was generated with Americium 1.5.1
 
 ## Normalization
 
 Americium currently uses a fixed internal randomisation seed, so always yields the same shrinkage:
 
-* ``[10, 10]`` - casesLimit = 3500
+* ``[10, 10]`` - casesLimit = 300
 
 
 ## Performance
 
-1615 cases were run.
+1516 cases were run.
 
-992 successful runs were performed out of a limit of 3500 successful cases, prior to the first failing case.
+250 successful runs were performed out of a limit of 300 successful cases, prior to the first failing case.
 
-1 + 1 = 2 runs then failed out of a subsequent shrinkage sequence of 1615 - 992 = 623 runs, including the first failing case.
+1 + 3 = 4 runs then failed out of a subsequent shrinkage sequence of 1516 - 250 = 1266 runs, including the first failing case.
 
-The best shrunk case was followed by 1615 - 1292 = 323 successful cases in the shrinkage sequence.
+The best shrunk case was followed by 1516 - 1009 = 507 successful cases in the shrinkage sequence.

--- a/pbt-libraries/americium/reports/lengthlist.md
+++ b/pbt-libraries/americium/reports/lengthlist.md
@@ -1,21 +1,21 @@
 # Report for Americium Shrinking on "lengthlist"
 
-This report was generated with Americium 1.4.6
+This report was generated with Americium 1.5.1
 
 ## Normalization
 
 Americium currently uses a fixed internal randomisation seed, so always yields the same shrinkage:
 
-* ``[[900]]`` - casesLimit = 180
+* ``[[900]]`` - casesLimit = 200
 
 ## Performance
 
-725 cases were run.
+753 cases were run.
 
-0 successful runs were performed out of a limit of 180 successful cases, prior to the first failing case.
+0 successful runs were performed out of a limit of 200 successful cases, prior to the first failing case.
 
-1 + 14 = 15 runs then failed out of a subsequent shrinkage sequence of 725 - 0 = 725 runs, including the first failing case.
+1 + 12 = 13 runs then failed out of a subsequent shrinkage sequence of 753 - 0 = 753 runs, including the first failing case.
 
-The best shrunk case was followed by 725 - 526 = 199 successful cases in the shrinkage sequence.
+The best shrunk case was followed by 753 - 516 = 237 successful cases in the shrinkage sequence.
 
 

--- a/pbt-libraries/americium/reports/nestedlists.md
+++ b/pbt-libraries/americium/reports/nestedlists.md
@@ -1,6 +1,6 @@
 # Report for Americium Shrinking on "nestedlists"
 
-This report was generated with Americium 1.4.6
+This report was generated with Americium 1.5.1
 
 ## Normalization
 
@@ -10,12 +10,12 @@ Americium currently uses a fixed internal randomisation seed, so always yields t
 
 ## Performance
 
-1248 cases were run.
+517 cases were run.
 
 78 successful runs were performed out of a limit of 500 successful cases, prior to the first failing case.
 
-1 + 5 = 6 runs then failed out of a subsequent shrinkage sequence of 1248 - 78 = 1170 runs, including the first failing case.
+1 + 5 = 6 runs then failed out of a subsequent shrinkage sequence of 517 - 78 = 439 runs, including the first failing case.
 
-The best shrunk case was followed by 1248 - 930 = 318 successful cases in the shrinkage sequence.
+The best shrunk case was followed by 517 - 515 = 2 successful cases in the shrinkage sequence.
 
 

--- a/pbt-libraries/americium/src/test/java/challenges/binheap/HeapTest.java
+++ b/pbt-libraries/americium/src/test/java/challenges/binheap/HeapTest.java
@@ -28,7 +28,7 @@ public class HeapTest {
                                         heaps(head).map(right -> new Heap(head, left, right)))));
     }
 
-    @TrialsTest(trials = {"heaps"}, casesLimit = 170)
+    @TrialsTest(trials = {"heaps"}, casesLimit = 190)
     void testWithIncorrectSort(Heap h) {
         List<Integer> l1 = toList(h);
         List<Integer> l2 = wrongToSortedList(h);

--- a/pbt-libraries/americium/src/test/java/challenges/difference/DifferenceTest.java
+++ b/pbt-libraries/americium/src/test/java/challenges/difference/DifferenceTest.java
@@ -1,8 +1,12 @@
 package challenges.difference;
 
+import com.google.common.collect.Maps;
 import com.sageserpent.americium.java.Trials;
 import com.sageserpent.americium.java.TrialsApi;
 import com.sageserpent.americium.java.TrialsTest;
+
+import java.util.Map;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,14 +16,15 @@ public class DifferenceTest {
 
     private final static int maximumPowerOfTwo = Integer.bitCount(Integer.MAX_VALUE);
 
+    // Have to work hard to get Americium to root out the failing cases - by default, the integers will
+    // vary wildly from 0 to `Integer.MAX_VALUE`. An interesting thought experiment is to imagine what
+    // would happen if the exclusion range for failures was increased from 10 to some large number...
     private final static Trials<Integer> positivesFavouringSmallerValues =
-            api.integers(1, maximumPowerOfTwo).flatMap(power -> {
-                final int basePowerOfTwo = 1 << (power - 1);
-                final int offsetUpperBound = basePowerOfTwo - 1;
-                return api.integers(0, offsetUpperBound).map(offset -> basePowerOfTwo + offset);
-            });
+            api.alternateWithWeights(IntStream.range(1, maximumPowerOfTwo)
+                    .mapToObj(power -> Maps.immutableEntry(Math.max(1, maximumPowerOfTwo - power), api.integers(0, (2 << power) - 1)))
+                    .toArray(Map.Entry[]::new));
 
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 2500)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 1000)
     void mustNotBeZero(int first, int second) {
         if (first < 10) {
             return;
@@ -28,7 +33,7 @@ public class DifferenceTest {
         assertThat(difference).isNotZero();
     }
 
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 500)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 150)
     void mustNotBeSmall(int first, int second) {
         if (first < 10) {
             return;
@@ -37,7 +42,7 @@ public class DifferenceTest {
         assertThat(1 > difference || difference > 4).isTrue();
     }
 
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 4300)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 400)
     void mustNotBeOne(int first, int second) {
         if (first < 10) {
             return;

--- a/pbt-libraries/americium/src/test/java/challenges/difference/DifferenceTest.java
+++ b/pbt-libraries/americium/src/test/java/challenges/difference/DifferenceTest.java
@@ -1,14 +1,11 @@
 package challenges.difference;
 
-import com.google.common.collect.Maps;
 import com.sageserpent.americium.java.Trials;
 import com.sageserpent.americium.java.TrialsApi;
 import com.sageserpent.americium.java.TrialsTest;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,15 +15,11 @@ public class DifferenceTest {
 
     private final static int maximumPowerOfTwo = Integer.bitCount(Integer.MAX_VALUE);
 
-    // Have to work hard to get Americium to root out the failing cases - by default, the integers will
-    // vary wildly from 0 to `Integer.MAX_VALUE`. An interesting thought experiment is to imagine what
-    // would happen if the exclusion range for failures was increased from 10 to some large number...
-    private final static Trials<Integer> positivesFavouringSmallerValues =
-            api.alternateWithWeights(IntStream.range(1, maximumPowerOfTwo)
-                    .mapToObj(power -> Maps.immutableEntry(Math.max(1, maximumPowerOfTwo - power), api.integers(0, (2 << power) - 1)))
-                    .toArray(Map.Entry[]::new));
+    private static final int scaleForClusteredValues = 10000;
 
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 3500)
+    private static final Trials<Integer> positivesFavouringSmallerValues = api.integers(1, 1 << (maximumPowerOfTwo / 3)).map(x -> (scaleForClusteredValues + x * x) * x / (scaleForClusteredValues + x));
+
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 850)
     void mustNotBeZero(int first, int second) {
         if (first < 10) {
             return;
@@ -35,7 +28,7 @@ public class DifferenceTest {
         assertThat(difference).isNotZero();
     }
 
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 150)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 2000)
     void mustNotBeSmall(int first, int second) {
         if (first < 10) {
             return;
@@ -44,32 +37,7 @@ public class DifferenceTest {
         assertThat(1 > difference || difference > 4).isTrue();
     }
 
-    // The thought experiment alluded to above...
-    @Test
-    void mustNotBeSmallVariationWithLargerExclusionZone() {
-        final AtomicLong counter = new AtomicLong(0L);
-
-        positivesFavouringSmallerValues.and(positivesFavouringSmallerValues).withLimit(10000).supplyTo((first, second) -> {
-            counter.incrementAndGet();
-
-            try {
-                // If the limit for trivial passes is increased to *449*, this test will pass,
-                // despite the large number of test cases examined. The thing is, 449 isn't that
-                // large a number. The issue here is that the test logic intrinsically favours
-                // distributions that have a higher frequency around zero before shrinkage even
-                // comes into play.
-                if (first < 448) {
-                    return;
-                }
-                int difference = Math.abs(first - second);
-                assertThat(1 > difference || difference > 4).isTrue();
-            } finally {
-                System.out.format("First: %d, second: %d, number of cases examined so far: %d\n", first, second, counter.get());
-            }
-        });
-    }
-
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 1000)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 32000)
     void mustNotBeOne(int first, int second) {
         if (first < 10) {
             return;

--- a/pbt-libraries/americium/src/test/java/challenges/difference/DifferenceTest.java
+++ b/pbt-libraries/americium/src/test/java/challenges/difference/DifferenceTest.java
@@ -3,9 +3,6 @@ package challenges.difference;
 import com.sageserpent.americium.java.Trials;
 import com.sageserpent.americium.java.TrialsApi;
 import com.sageserpent.americium.java.TrialsTest;
-import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,11 +12,14 @@ public class DifferenceTest {
 
     private final static int maximumPowerOfTwo = Integer.bitCount(Integer.MAX_VALUE);
 
-    private static final int scaleForClusteredValues = 10000;
+    private final static Trials<Integer> positivesFavouringSmallerValues =
+            api.integers(1, maximumPowerOfTwo).flatMap(power -> {
+                final int basePowerOfTwo = 1 << (power - 1);
+                final int offsetUpperBound = basePowerOfTwo - 1;
+                return api.integers(0, offsetUpperBound).map(offset -> basePowerOfTwo + offset);
+            });
 
-    private static final Trials<Integer> positivesFavouringSmallerValues = api.integers(1, 1 << (maximumPowerOfTwo / 3)).map(x -> (scaleForClusteredValues + x * x) * x / (scaleForClusteredValues + x));
-
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 850)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 2500)
     void mustNotBeZero(int first, int second) {
         if (first < 10) {
             return;
@@ -28,7 +28,7 @@ public class DifferenceTest {
         assertThat(difference).isNotZero();
     }
 
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 2000)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 500)
     void mustNotBeSmall(int first, int second) {
         if (first < 10) {
             return;
@@ -37,7 +37,7 @@ public class DifferenceTest {
         assertThat(1 > difference || difference > 4).isTrue();
     }
 
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 32000)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 4300)
     void mustNotBeOne(int first, int second) {
         if (first < 10) {
             return;
@@ -45,5 +45,4 @@ public class DifferenceTest {
         int difference = Math.abs(first - second);
         assertThat(difference).isNotEqualTo(1);
     }
-
 }

--- a/pbt-libraries/americium/src/test/java/challenges/difference/DifferenceTest.java
+++ b/pbt-libraries/americium/src/test/java/challenges/difference/DifferenceTest.java
@@ -1,12 +1,8 @@
 package challenges.difference;
 
-import com.google.common.collect.Maps;
 import com.sageserpent.americium.java.Trials;
 import com.sageserpent.americium.java.TrialsApi;
 import com.sageserpent.americium.java.TrialsTest;
-
-import java.util.Map;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,17 +10,12 @@ public class DifferenceTest {
 
     private final static TrialsApi api = Trials.api();
 
-    private final static int maximumPowerOfTwo = Integer.bitCount(Integer.MAX_VALUE);
+    private final static int logMaxValue = (int) Math.floor(Math.log10(Integer.MAX_VALUE));
 
-    // Have to work hard to get Americium to root out the failing cases - by default, the integers will
-    // vary wildly from 0 to `Integer.MAX_VALUE`. An interesting thought experiment is to imagine what
-    // would happen if the exclusion range for failures was increased from 10 to some large number...
     private final static Trials<Integer> positivesFavouringSmallerValues =
-            api.alternateWithWeights(IntStream.range(1, maximumPowerOfTwo)
-                    .mapToObj(power -> Maps.immutableEntry(Math.max(1, maximumPowerOfTwo - power), api.integers(0, (2 << power) - 1)))
-                    .toArray(Map.Entry[]::new));
+            api.integers(0, 100 * logMaxValue).map(value -> (int) Math.round(Math.pow(10, (double) value / 100)));
 
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 1000)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 300)
     void mustNotBeZero(int first, int second) {
         if (first < 10) {
             return;
@@ -33,7 +24,7 @@ public class DifferenceTest {
         assertThat(difference).isNotZero();
     }
 
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 150)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 1700)
     void mustNotBeSmall(int first, int second) {
         if (first < 10) {
             return;
@@ -42,7 +33,7 @@ public class DifferenceTest {
         assertThat(1 > difference || difference > 4).isTrue();
     }
 
-    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 400)
+    @TrialsTest(trials = {"positivesFavouringSmallerValues", "positivesFavouringSmallerValues"}, casesLimit = 2000)
     void mustNotBeOne(int first, int second) {
         if (first < 10) {
             return;

--- a/pbt-libraries/americium/src/test/java/challenges/lengthlist/LengthListTest.java
+++ b/pbt-libraries/americium/src/test/java/challenges/lengthlist/LengthListTest.java
@@ -15,7 +15,7 @@ public class LengthListTest {
 
     final private static int limit = 900;
 
-    @TrialsTest(trials = "listsOfBoundedLengthAndElementValue", casesLimit = 180)
+    @TrialsTest(trials = "listsOfBoundedLengthAndElementValue", casesLimit = 200)
     void allElementShouldBeBelowLimit(ImmutableList<Integer> list) {
         assertThat(list).allSatisfy(element -> assertThat(element).isLessThan(limit));
     }


### PR DESCRIPTION
Hello @jlink  - another PR for the update of Americium to 1.5.1. This should be the last for a while.

I've rebased the latest commits, the merge should be clean.

The difference reports have changed significantly as I've used a more principled formulation of the DSL to generate the test cases - it's simpler and less contrived. This does mean the tests have to work a lot harder to find initial failing cases, but so be it, the idea is not to know too much about the bug in the first place.